### PR TITLE
Fix duplicating chunks

### DIFF
--- a/HtmlWebpackIncludeSiblingChunksPlugin.js
+++ b/HtmlWebpackIncludeSiblingChunksPlugin.js
@@ -1,9 +1,15 @@
-class HtmlWebpackIncludeSiblingChunksPlugin {
-  toMap(map, item) {
-    map[item.id] = item
-    return map
-  }
+// Use in .reduce, to convert array to map, with keys = item.id
+const toMap = (map, item) => {
+  map[item.id] = item
+  return map
+}
 
+// Use in .filter, to remove duplicating items from array
+const onlyUnique = (item, i, array) =>
+  array.indexOf(item) === i
+
+//
+class HtmlWebpackIncludeSiblingChunksPlugin {
   apply(compiler) {
     compiler.hooks.emit.tap('HtmlWebpackIncludeSiblingChunksPlugin', compilation => {
       const chunkOnlyConfig = {
@@ -22,10 +28,10 @@ class HtmlWebpackIncludeSiblingChunksPlugin {
         version: false
       }
 
-      const allChunks = compilation.getStats().toJson(chunkOnlyConfig).chunks.reduce(this.toMap, Object.create(null))
+      const allChunks = compilation.getStats().toJson(chunkOnlyConfig).chunks.reduce(toMap, Object.create(null))
 
       compilation.hooks.htmlWebpackPluginAlterChunks.tap('HtmlWebpackIncludeSiblingChunksPlugin', chunks => {
-        const ids = [].concat(...chunks.map(chunk => [...chunk.siblings, chunk.id]))
+        const ids = [].concat(...chunks.map(chunk => [...chunk.siblings, chunk.id])).filter(onlyUnique)
         return ids.map(id => allChunks[id])
       })
     })


### PR DESCRIPTION
If you use more than one chunk in HtmlWebpackPlugin, and they have common sibling chunks – they all goes to page.

For example, if you have
```js
optimization: {
  runtimeChunk: {
    name: 'runtime'
  }
}

// --- 8< ---

new HtmlWebpackPlugin({
  // ...
  chunks: ['app', 'templates']
})
```
both, `app` and `templates` chunks will have same `runtime` chunk in siblings array.

Also I've moved functions from class, because they don't belong to class, logically