### PR TITLE
Respect existing chunks order

### DIFF
--- a/HtmlWebpackIncludeSiblingChunksPlugin.js
+++ b/HtmlWebpackIncludeSiblingChunksPlugin.js
@@ -31,7 +31,10 @@ class HtmlWebpackIncludeSiblingChunksPlugin {
       const allChunks = compilation.getStats().toJson(chunkOnlyConfig).chunks.reduce(toMap, Object.create(null))
 
       compilation.hooks.htmlWebpackPluginAlterChunks.tap('HtmlWebpackIncludeSiblingChunksPlugin', chunks => {
-        const ids = [].concat(...chunks.map(chunk => [...chunk.siblings, chunk.id])).filter(onlyUnique)
+        const ids = [].concat(...chunks.map(chunk => {
+          const siblings = chunk.siblings.filter(id => !chunks.find(c => c.id === id))
+          return [...siblings, chunk.id]
+        })).filter(onlyUnique)
         return ids.map(id => allChunks[id])
       })
     })


### PR DESCRIPTION
Only put fresh siblings ahead of the original chunk.

Current implementation breaks chunks order when 

* Chunks: [1, 2 ,3]
* 1.siblings = [2]

So it turns the final chunks to [2, 1, 3]